### PR TITLE
Improvements and extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /*.log
 /dist
 /gpxmerge.egg-info
+/__pycache__

--- a/gpxmerger.py
+++ b/gpxmerger.py
@@ -59,7 +59,7 @@ def load_gpxs(track_files):
             gpxs.append(gpx)
             nsmap.update(gpx.nsmap)
 
-    logger.debug('loaded a total of {s} files'.format(s=len(gpxs)))
+    logger.debug('Loaded a total of {s} files'.format(s=len(gpxs)))
     return gpxs
 
 
@@ -67,7 +67,7 @@ def load_tracks(track_files):
     logger = logging.getLogger(__name__)
     gpxs = load_gpxs(track_files)
     tracks = sum((gpx.tracks for gpx in gpxs), [])
-    logger.debug('loaded a total of {s} tracks'.format(s=len(tracks)))
+    logger.debug('Loaded a total of {s} tracks'.format(s=len(tracks)))
     return tracks
 
 
@@ -75,7 +75,7 @@ def load_segments(track_files):
     logger = logging.getLogger(__name__)
     tracks = load_tracks(track_files)
     segments = sum((track.segments for track in tracks), [])
-    logger.debug('loaded a total of {s} segments'.format(s=len(segments)))
+    logger.debug('Loaded a total of {s} segments'.format(s=len(segments)))
     return segments
 
 
@@ -85,7 +85,7 @@ def load_points(track_files):
     points = sum((segment.points for segment in segments), [])
     points = list(filter(lambda x: x.time is not None, points))
     points = sorted(points, key=lambda p: p.time)
-    logger.debug('loaded a total of {s} points'.format(s=len(points)))
+    logger.debug('Loaded a total of {s} points'.format(s=len(points)))
     return points
 
 
@@ -146,7 +146,7 @@ def get_target(files, target=None):
     if not target.endswith(ext):
         target += ext
 
-    logger.debug("write result to: {f}".format(f=target))
+    logger.debug("Write result to: {f}".format(f=target))
     return target
 
 
@@ -156,7 +156,7 @@ def get_name(target):
 
 def merge(files, target=None, segment=False, track=False):
     logger = logging.getLogger(__name__)
-    logger.info("start new merge process")
+    logger.info("Start new merge process")
     track_files = filter(is_gpx, files)
 
     if segment:
@@ -177,10 +177,10 @@ def merge(files, target=None, segment=False, track=False):
 
 def main():
     parser = argparse.ArgumentParser(description="A simple script to merge multiple GPX files into one large GPX file.")
-    parser.add_argument("input_files", nargs="*", help="Input files to merge")
-    parser.add_argument("-o", help="Output file name, path or directory")
-    parser.add_argument("-s", default=False, action="store_true", help=("Merge segments"))
-    parser.add_argument("-t", default=False, action="store_true", help=("Merge tracks"))
+    parser.add_argument("input_files", nargs="*", help="input files to merge")
+    parser.add_argument("-o", help="output file name, path or directory")
+    parser.add_argument("-s", default=False, action="store_true", help=("merge segments"))
+    parser.add_argument("-t", default=False, action="store_true", help=("merge tracks"))
 
     if len(sys.argv[1:]) == 0:
         parser.print_help()

--- a/gpxmerger.py
+++ b/gpxmerger.py
@@ -79,7 +79,7 @@ def load_points(track_files):
     return points
 
 
-def to_xml(data):
+def to_xml(data, name=""):
     logger = logging.getLogger(__name__)
     gpx = gpxpy.gpx.GPX()
     
@@ -89,7 +89,7 @@ def to_xml(data):
         
     else:
         # Create first track in our GPX:
-        gpx_track = gpxpy.gpx.GPXTrack()
+        gpx_track = gpxpy.gpx.GPXTrack(name)
         gpx.tracks.append(gpx_track)
         
         if isinstance(data[0], gpxpy.gpx.GPXTrackSegment):
@@ -131,6 +131,10 @@ def get_target(files, target=None):
     return target
 
 
+def get_name(target):
+    return path.splitext(path.basename(target))[0]
+
+
 def save_target(xml, target_file):
     logger = logging.getLogger(__name__)
     with open(target_file, 'w') as fp:
@@ -153,8 +157,9 @@ def merge(files, target=None, segment=False, track=False):
     else:
         data = load_points(track_files)
 
-    xml = to_xml(data)
     target_file = get_target(files, target)
+    name = get_name(target_file)
+    xml = to_xml(data, name)
     save_target(xml, target_file)
     logger.info("Finish")
 

--- a/gpxmerger.py
+++ b/gpxmerger.py
@@ -47,19 +47,26 @@ def is_gpx(filename):
     logger.debug('checking {f}'.format(f=filename))
     return ext == '.gpx'
 
-
-def load_tracks(track_files):
+def load_gpxs(track_files):
     logger = logging.getLogger(__name__)
-    tracks = []
+    gpxs = []
 
     for track_file in track_files:
         with open(track_file, 'r') as gpx_file:
             gpx_parser = parser.GPXParser(gpx_file)
             gpx_parser.parse()
             gpx = gpx_parser.gpx
-            tracks.extend(gpx.tracks)
+            gpxs.append(gpx)
             nsmap.update(gpx.nsmap)
 
+    logger.debug('loaded a total of {s} files'.format(s=len(gpxs)))
+    return gpxs
+
+
+def load_tracks(track_files):
+    logger = logging.getLogger(__name__)
+    gpxs = load_gpxs(track_files)
+    tracks = sum((gpx.tracks for gpx in gpxs), [])
     logger.debug('loaded a total of {s} tracks'.format(s=len(tracks)))
     return tracks
 

--- a/gpxmerger.py
+++ b/gpxmerger.py
@@ -3,7 +3,6 @@ import logging
 import logging.config
 import gpxpy
 import gpxpy.parser as parser
-from gpxpy.gpx import GPXTrackPoint
 from os import path
 
 # https://fangpenlin.com/posts/2012/08/26/good-logging-practice-in-python/

--- a/gpxmerger.py
+++ b/gpxmerger.py
@@ -104,7 +104,7 @@ def main(argv):
     logger = logging.getLogger(__name__)
     logger.info("start new merge process")
 
-    track_files = [f for f in argv if is_gpx(f)]
+    track_files = filter(is_gpx, argv)
     points = get_all_points(track_files)
     points = filter(lambda x: x.time is not None, points)
     sorted_points = sorted(points, key=lambda p: p.time)

--- a/gpxmerger.py
+++ b/gpxmerger.py
@@ -3,7 +3,7 @@ import sys
 import logging
 import logging.config
 import gpxpy
-import gpxpy.parser as parser
+from gpxpy import parse
 from os import path
 
 nsmap = {}
@@ -55,9 +55,7 @@ def load_gpxs(track_files):
 
     for track_file in track_files:
         with open(track_file, "r") as gpx_file:
-            gpx_parser = parser.GPXParser(gpx_file)
-            gpx_parser.parse()
-            gpx = gpx_parser.gpx
+            gpx = parse(gpx_file)
             gpxs.append(gpx)
             nsmap.update(gpx.nsmap)
 

--- a/gpxmerger.py
+++ b/gpxmerger.py
@@ -1,3 +1,4 @@
+import argparse
 import sys
 import logging
 import logging.config
@@ -120,7 +121,15 @@ def merge(files):
 
 
 def main():
-    merge(sys.argv[1:])
+    parser = argparse.ArgumentParser(description="A simple script to merge multiple GPX files into one large GPX file.")
+    parser.add_argument("input_files", nargs="*", help="Input files to merge")
+
+    if len(sys.argv[1:]) == 0:
+        parser.print_help()
+        parser.exit()
+
+    args = parser.parse_args()
+    merge(args.input_files)
 
 
 if __name__ == '__main__':

--- a/gpxmerger.py
+++ b/gpxmerger.py
@@ -64,11 +64,7 @@ def load_tracks(track_files):
 def load_segments(track_files):
     logger = logging.getLogger(__name__)
     tracks = load_tracks(track_files)
-    segments = []
-
-    for track in tracks:
-        segments.extend(track.segments)
-
+    segments = sum((track.segments for track in tracks), [])
     logger.debug('loaded a total of {s} segments'.format(s=len(segments)))
     return segments
 
@@ -76,11 +72,7 @@ def load_segments(track_files):
 def load_points(track_files):
     logger = logging.getLogger(__name__)
     segments = load_segments(track_files)
-    points = []
-
-    for segment in segments:
-        points.extend(segment.points)
-
+    points = sum((segment.points for segment in segments), [])
     points = list(filter(lambda x: x.time is not None, points))
     points = sorted(points, key=lambda p: p.time)
     logger.debug('loaded a total of {s} points'.format(s=len(points)))

--- a/gpxmerger.py
+++ b/gpxmerger.py
@@ -89,13 +89,13 @@ def load_points(track_files):
     return points
 
 
-def to_xml(data, name=""):
+def get_gpx(data, name=""):
     logger = logging.getLogger(__name__)
     gpx = gpxpy.gpx.GPX()
     gpx.nsmap.update(nsmap)
     
     if isinstance(data[0], gpxpy.gpx.GPXTrack):
-        logger.debug('converting {s} tracks to XML'.format(s=len(data)))
+        logger.debug('Generating GPX with {s} tracks'.format(s=len(data)))
         gpx.tracks.extend(data)
         
     else:
@@ -104,7 +104,7 @@ def to_xml(data, name=""):
         gpx.tracks.append(gpx_track)
         
         if isinstance(data[0], gpxpy.gpx.GPXTrackSegment):
-            logger.debug('converting {s} segments to XML'.format(s=len(data)))
+            logger.debug('Generating GPX with {s} segments'.format(s=len(data)))
             gpx_track.segments.extend(data)
             
         elif isinstance(data[0], gpxpy.gpx.GPXTrackPoint):
@@ -112,12 +112,20 @@ def to_xml(data, name=""):
             gpx_segment = gpxpy.gpx.GPXTrackSegment()
             gpx_track.segments.append(gpx_segment)
             
-            logger.debug('converting {s} points to XML'.format(s=len(data)))
+            logger.debug('Generating GPX with {s} points'.format(s=len(data)))
         
             # Add points:
             gpx_segment.points.extend(data)
 
-    return gpx.to_xml()
+    return gpx
+
+
+def save(gpx, target_file):
+    with open(target_file, 'w') as fp:
+        logger = logging.getLogger(__name__)
+        logger.debug('Saving "{f}"'.format(f=target_file))
+        fp.write(gpx.to_xml())
+        logger.debug('Done saving')
 
 
 def get_target(files, target=None):
@@ -146,14 +154,6 @@ def get_name(target):
     return path.splitext(path.basename(target))[0]
 
 
-def save_target(xml, target_file):
-    logger = logging.getLogger(__name__)
-    with open(target_file, 'w') as fp:
-        logger.debug('saving "{f}"'.format(f=target_file))
-        fp.write(xml)
-        logger.debug('done saving')
-
-
 def merge(files, target=None, segment=False, track=False):
     logger = logging.getLogger(__name__)
     logger.info("start new merge process")
@@ -170,8 +170,8 @@ def merge(files, target=None, segment=False, track=False):
 
     target_file = get_target(files, target)
     name = get_name(target_file)
-    xml = to_xml(data, name)
-    save_target(xml, target_file)
+    gpx = get_gpx(data, name)
+    save(gpx, target_file)
     logger.info("Finish")
 
 

--- a/gpxmerger.py
+++ b/gpxmerger.py
@@ -86,6 +86,8 @@ def get_all_points(track_files):
     for f in track_files:
         points.extend(load_points(f))
 
+    points = filter(lambda x: x.time is not None, points)
+    points = sorted(points, key=lambda p: p.time)
     logger.debug('loaded a total of {s} points'.format(s=len(points)))
     return points
 
@@ -126,9 +128,7 @@ def merge(files, target=None):
 
     track_files = filter(is_gpx, files)
     points = get_all_points(track_files)
-    points = filter(lambda x: x.time is not None, points)
-    sorted_points = sorted(points, key=lambda p: p.time)
-    xml = to_xml(sorted_points)
+    xml = to_xml(points)
 
     target_file = get_target(files, target)
     save_target(xml, target_file)

--- a/gpxmerger.py
+++ b/gpxmerger.py
@@ -7,6 +7,7 @@ import gpxpy.parser as parser
 from os import path
 
 nsmap = {}
+ext = ".gpx"
 
 # https://fangpenlin.com/posts/2012/08/26/good-logging-practice-in-python/
 logging.basicConfig(level=logging.DEBUG)
@@ -42,10 +43,9 @@ logging.config.dictConfig({
 
 def is_gpx(filename):
     logger = logging.getLogger(__name__)
-    ext = path.splitext(filename)[1]
+    logger.debug('Checking {f}'.format(f=filename))
+    return path.splitext(filename)[1] == ext
 
-    logger.debug('checking {f}'.format(f=filename))
-    return ext == '.gpx'
 
 def load_gpxs(track_files):
     logger = logging.getLogger(__name__)
@@ -143,8 +143,8 @@ def get_target(files, target=None):
 
         target = path.join(dirname, filename)
 
-    if not target.endswith(".gpx"):
-        target += ".gpx"
+    if not target.endswith(ext):
+        target += ext
 
     logger.debug("write result to: {f}".format(f=target))
     return target

--- a/gpxmerger.py
+++ b/gpxmerger.py
@@ -101,6 +101,14 @@ def get_target(files):
     return target
 
 
+def save_target(xml, target_file):
+    logger = logging.getLogger(__name__)
+    with open(target_file, 'w') as fp:
+        logger.debug('saving "{f}"'.format(f=target_file))
+        fp.write(xml)
+        logger.debug('done saving')
+
+
 def merge(files):
     logger = logging.getLogger(__name__)
     logger.info("start new merge process")
@@ -112,10 +120,7 @@ def merge(files):
     xml = to_xml(sorted_points)
 
     target_file = get_target(files)
-    with open(target_file, 'w') as fp:
-        logger.debug('saving "{f}"'.format(f=target_file))
-        fp.write(xml)
-        logger.debug('done saving')
+    save_target(xml, target_file)
 
     logger.info("Finish")
 

--- a/gpxmerger.py
+++ b/gpxmerger.py
@@ -37,8 +37,6 @@ logging.config.dictConfig({
     }
 })
 
-target_filename = 'merged.gpx'
-
 
 def is_gpx(filename):
     logger = logging.getLogger(__name__)
@@ -92,11 +90,24 @@ def get_all_points(track_files):
     return points
 
 
-def get_target(files):
+def get_target(files, target=None):
     logger = logging.getLogger(__name__)
-    file = files[0]
-    dir_name = path.dirname(file)
-    target = path.join(dir_name, target_filename)
+
+    if not target or not path.isfile(target):
+        filename = "merged"
+        dirname = path.dirname(files[0])
+
+        if target and path.isdir(target):
+            dirname = target
+
+        elif target:
+            filename = target
+
+        target = path.join(dirname, filename)
+
+    if not target.endswith(".gpx"):
+        target += ".gpx"
+
     logger.debug("write result to: {f}".format(f=target))
     return target
 
@@ -109,7 +120,7 @@ def save_target(xml, target_file):
         logger.debug('done saving')
 
 
-def merge(files):
+def merge(files, target=None):
     logger = logging.getLogger(__name__)
     logger.info("start new merge process")
 
@@ -119,7 +130,7 @@ def merge(files):
     sorted_points = sorted(points, key=lambda p: p.time)
     xml = to_xml(sorted_points)
 
-    target_file = get_target(files)
+    target_file = get_target(files, target)
     save_target(xml, target_file)
 
     logger.info("Finish")
@@ -128,13 +139,14 @@ def merge(files):
 def main():
     parser = argparse.ArgumentParser(description="A simple script to merge multiple GPX files into one large GPX file.")
     parser.add_argument("input_files", nargs="*", help="Input files to merge")
+    parser.add_argument("-o", help="Output file name, path or directory")
 
     if len(sys.argv[1:]) == 0:
         parser.print_help()
         parser.exit()
 
     args = parser.parse_args()
-    merge(args.input_files)
+    merge(args.input_files, args.o)
 
 
 if __name__ == '__main__':

--- a/gpxmerger.py
+++ b/gpxmerger.py
@@ -100,17 +100,17 @@ def get_target(files):
     return target
 
 
-def main(argv):
+def merge(files):
     logger = logging.getLogger(__name__)
     logger.info("start new merge process")
 
-    track_files = filter(is_gpx, argv)
+    track_files = filter(is_gpx, files)
     points = get_all_points(track_files)
     points = filter(lambda x: x.time is not None, points)
     sorted_points = sorted(points, key=lambda p: p.time)
     xml = to_xml(sorted_points)
 
-    target_file = get_target(argv)
+    target_file = get_target(files)
     with open(target_file, 'w') as fp:
         logger.debug('saving "{f}"'.format(f=target_file))
         fp.write(xml)
@@ -119,5 +119,9 @@ def main(argv):
     logger.info("Finish")
 
 
+def main():
+    merge(sys.argv[1:])
+
+
 if __name__ == '__main__':
-    main(sys.argv[1:])
+    main()

--- a/gpxmerger.py
+++ b/gpxmerger.py
@@ -11,39 +11,41 @@ ext = ".gpx"
 
 # https://fangpenlin.com/posts/2012/08/26/good-logging-practice-in-python/
 logging.basicConfig(level=logging.DEBUG)
-logging.config.dictConfig({
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'standard': {
-            'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
-        }
-    },
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-            'stream': 'ext://sys.stdout'
+logging.config.dictConfig(
+    {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "standard": {
+                "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+            }
         },
-        'file': {
-            'level': 'DEBUG',
-            'class': 'logging.FileHandler',
-            'filename': 'gpxmerger.log',
-            'formatter': 'standard'
-        }
-    },
-    'loggers': {
-        '__main__': {  # name my module
-            'level': 'DEBUG',
-            'propagate': True,
-            'handlers': ['file']
-        }
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stdout",
+            },
+            "file": {
+                "level": "DEBUG",
+                "class": "logging.FileHandler",
+                "filename": "gpxmerger.log",
+                "formatter": "standard",
+            },
+        },
+        "loggers": {
+            "__main__": {  # name my module
+                "level": "DEBUG",
+                "propagate": True,
+                "handlers": ["file"],
+            }
+        },
     }
-})
+)
 
 
 def is_gpx(filename):
     logger = logging.getLogger(__name__)
-    logger.debug('Checking {f}'.format(f=filename))
+    logger.debug("Checking {f}".format(f=filename))
     return path.splitext(filename)[1] == ext
 
 
@@ -52,14 +54,14 @@ def load_gpxs(track_files):
     gpxs = []
 
     for track_file in track_files:
-        with open(track_file, 'r') as gpx_file:
+        with open(track_file, "r") as gpx_file:
             gpx_parser = parser.GPXParser(gpx_file)
             gpx_parser.parse()
             gpx = gpx_parser.gpx
             gpxs.append(gpx)
             nsmap.update(gpx.nsmap)
 
-    logger.debug('Loaded a total of {s} files'.format(s=len(gpxs)))
+    logger.debug("Loaded a total of {s} files".format(s=len(gpxs)))
     return gpxs
 
 
@@ -67,7 +69,7 @@ def load_tracks(track_files):
     logger = logging.getLogger(__name__)
     gpxs = load_gpxs(track_files)
     tracks = sum((gpx.tracks for gpx in gpxs), [])
-    logger.debug('Loaded a total of {s} tracks'.format(s=len(tracks)))
+    logger.debug("Loaded a total of {s} tracks".format(s=len(tracks)))
     return tracks
 
 
@@ -75,7 +77,7 @@ def load_segments(track_files):
     logger = logging.getLogger(__name__)
     tracks = load_tracks(track_files)
     segments = sum((track.segments for track in tracks), [])
-    logger.debug('Loaded a total of {s} segments'.format(s=len(segments)))
+    logger.debug("Loaded a total of {s} segments".format(s=len(segments)))
     return segments
 
 
@@ -85,7 +87,7 @@ def load_points(track_files):
     points = sum((segment.points for segment in segments), [])
     points = list(filter(lambda x: x.time is not None, points))
     points = sorted(points, key=lambda p: p.time)
-    logger.debug('Loaded a total of {s} points'.format(s=len(points)))
+    logger.debug("Loaded a total of {s} points".format(s=len(points)))
     return points
 
 
@@ -93,27 +95,29 @@ def get_gpx(data, name=""):
     logger = logging.getLogger(__name__)
     gpx = gpxpy.gpx.GPX()
     gpx.nsmap.update(nsmap)
-    
+
     if isinstance(data[0], gpxpy.gpx.GPXTrack):
-        logger.debug('Generating GPX with {s} tracks'.format(s=len(data)))
+        logger.debug("Generating GPX with {s} tracks".format(s=len(data)))
         gpx.tracks.extend(data)
-        
+
     else:
         # Create first track in our GPX:
         gpx_track = gpxpy.gpx.GPXTrack(name)
         gpx.tracks.append(gpx_track)
-        
+
         if isinstance(data[0], gpxpy.gpx.GPXTrackSegment):
-            logger.debug('Generating GPX with {s} segments'.format(s=len(data)))
+            logger.debug(
+                "Generating GPX with {s} segments".format(s=len(data))
+            )
             gpx_track.segments.extend(data)
-            
+
         elif isinstance(data[0], gpxpy.gpx.GPXTrackPoint):
             # Create first segment in our GPX track:
             gpx_segment = gpxpy.gpx.GPXTrackSegment()
             gpx_track.segments.append(gpx_segment)
-            
-            logger.debug('Generating GPX with {s} points'.format(s=len(data)))
-        
+
+            logger.debug("Generating GPX with {s} points".format(s=len(data)))
+
             # Add points:
             gpx_segment.points.extend(data)
 
@@ -121,11 +125,11 @@ def get_gpx(data, name=""):
 
 
 def save(gpx, target_file):
-    with open(target_file, 'w') as fp:
+    with open(target_file, "w") as fp:
         logger = logging.getLogger(__name__)
-        logger.debug('Saving "{f}"'.format(f=target_file))
+        logger.debug("Saving {f}".format(f=target_file))
         fp.write(gpx.to_xml())
-        logger.debug('Done saving')
+        logger.debug("Done saving")
 
 
 def get_target(files, target=None):
@@ -176,11 +180,17 @@ def merge(files, target=None, segment=False, track=False):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="A simple script to merge multiple GPX files into one large GPX file.")
+    parser = argparse.ArgumentParser(
+        description="A simple script to merge multiple GPX files into one large GPX file."
+    )
     parser.add_argument("input_files", nargs="*", help="input files to merge")
     parser.add_argument("-o", help="output file name, path or directory")
-    parser.add_argument("-s", default=False, action="store_true", help=("merge segments"))
-    parser.add_argument("-t", default=False, action="store_true", help=("merge tracks"))
+    parser.add_argument(
+        "-s", default=False, action="store_true", help=("merge segments")
+    )
+    parser.add_argument(
+        "-t", default=False, action="store_true", help=("merge tracks")
+    )
 
     if len(sys.argv[1:]) == 0:
         parser.print_help()
@@ -190,5 +200,5 @@ def main():
     merge(args.input_files, args.o, args.s, args.t)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/gpxmerger.py
+++ b/gpxmerger.py
@@ -6,6 +6,8 @@ import gpxpy
 import gpxpy.parser as parser
 from os import path
 
+nsmap = {}
+
 # https://fangpenlin.com/posts/2012/08/26/good-logging-practice-in-python/
 logging.basicConfig(level=logging.DEBUG)
 logging.config.dictConfig({
@@ -56,6 +58,7 @@ def load_tracks(track_files):
             gpx_parser.parse()
             gpx = gpx_parser.gpx
             tracks.extend(gpx.tracks)
+            nsmap.update(gpx.nsmap)
 
     logger.debug('loaded a total of {s} tracks'.format(s=len(tracks)))
     return tracks
@@ -82,6 +85,7 @@ def load_points(track_files):
 def to_xml(data, name=""):
     logger = logging.getLogger(__name__)
     gpx = gpxpy.gpx.GPX()
+    gpx.nsmap.update(nsmap)
     
     if isinstance(data[0], gpxpy.gpx.GPXTrack):
         logger.debug('converting {s} tracks to XML'.format(s=len(data)))


### PR DESCRIPTION
Inspired by using [gpxmerger](https://github.com/locked-fg/gpxmerger) to merge tracks of the same region recorded with [Geo Tracker](https://play.google.com/store/apps/details?id=com.ilyabogdanovich.geotracker), I made several improvements and extensions that I would like to share:

- Merging segments and tracks in addition to points (to avoid misconnected start and end points of tracks)
- Specifying the output file (e.g. for different regions)
- Setting track names (to find imported tracks like in [Geo Tracker](https://play.google.com/store/apps/details?id=com.ilyabogdanovich.geotracker))
- Fix xml namespace issues with gpxpy (e.g. in gpx extension fields)
- Python interface with merge function
- Command line interface with argparse in main function
- Code restructuring for reusability